### PR TITLE
Introduce app_id for identifying clients.

### DIFF
--- a/client/client.c
+++ b/client/client.c
@@ -309,6 +309,7 @@ static void parse_input(void)
     char     *rs;
     uint32_t  res[4];
     char     *audiogr;
+    char     *app_id;
     uint32_t  pid;
     char     *name;
     char     *value;
@@ -375,6 +376,7 @@ static void parse_input(void)
             msg.record.rset.opt   = res[1];
             msg.record.rset.share = res[2];
             msg.record.rset.mask  = res[3];
+            msg.record.app_id     = "none";
             msg.record.klass      = config.klass;
             manager_send_message(&msg);
         }
@@ -395,11 +397,7 @@ static void parse_input(void)
                 }
             }
 
-            if (!(pid = strtoul(p, &p, 10)) || (*p != ' ' && *p != '\t')) {
-                print_message("invalid pid");
-                break;
-            }
-
+            app_id = skip_whitespaces(p);
             name = skip_whitespaces(p);
 
             if ((p = strchr(name, ':')) == NULL) {
@@ -415,7 +413,7 @@ static void parse_input(void)
             memset(&msg, 0, sizeof(resmsg_t));
             msg.audio.type  = RESMSG_AUDIO;
             msg.audio.group = audiogr;
-            msg.audio.pid   = pid;
+            msg.audio.app_id= app_id;
             msg.audio.property.name = name;
             msg.audio.property.match.method  = resmsg_method_equals;
             msg.audio.property.match.pattern = value; 
@@ -614,6 +612,7 @@ static void connect_to_manager(resconn_t *rc)
     resmsg.record.rset.opt   = config.rset.opt;
     resmsg.record.rset.share = config.rset.share;
     resmsg.record.rset.mask  = config.rset.mask;
+    resmsg.record.app_id     = "none";
     resmsg.record.klass      = config.klass;
     resmsg.record.mode       = config.mode;
 

--- a/src/dbus-msg.c
+++ b/src/dbus-msg.c
@@ -68,6 +68,8 @@ DBusMessage *resmsg_dbus_compose_message(const char *dest,
                                  DBUS_TYPE_UINT32, &record->rset.opt,
                                  DBUS_TYPE_UINT32, &record->rset.share,
                                  DBUS_TYPE_UINT32, &record->rset.mask,
+                                 DBUS_TYPE_STRING,  record->app_id ?
+                                                   &record->app_id : &empty_str,
                                  DBUS_TYPE_STRING,  record->klass ?
                                                    &record->klass : &empty_str,
                                  DBUS_TYPE_UINT32, &record->mode,
@@ -105,7 +107,8 @@ DBusMessage *resmsg_dbus_compose_message(const char *dest,
                        DBUS_TYPE_UINT32, &audio->reqno,
                        DBUS_TYPE_STRING,  audio->group ?
                                          &audio->group : &empty_str,
-                       DBUS_TYPE_UINT32, &audio->pid,
+                       DBUS_TYPE_STRING,  audio->app_id ?
+                                         &audio->app_id : &empty_str,
                        DBUS_TYPE_STRING,  property->name ?
                                          &property->name : &empty_str,
                        DBUS_TYPE_INT32 , &property->match.method,
@@ -233,6 +236,7 @@ resmsg_t *resmsg_dbus_parse_message(DBusMessage *dbusmsg, resmsg_t *resmsg)
                                         DBUS_TYPE_UINT32, &record->rset.opt,
                                         DBUS_TYPE_UINT32, &record->rset.share,
                                         DBUS_TYPE_UINT32, &record->rset.mask,
+                                        DBUS_TYPE_STRING, &record->app_id,
                                         DBUS_TYPE_STRING, &record->klass,
                                         DBUS_TYPE_UINT32, &record->mode,
                                         DBUS_TYPE_INVALID);
@@ -270,7 +274,7 @@ resmsg_t *resmsg_dbus_parse_message(DBusMessage *dbusmsg, resmsg_t *resmsg)
                                         DBUS_TYPE_UINT32, &audio->id,
                                         DBUS_TYPE_UINT32, &audio->reqno,
                                         DBUS_TYPE_STRING, &audio->group,
-                                        DBUS_TYPE_UINT32, &audio->pid,
+                                        DBUS_TYPE_STRING, &audio->app_id,
                                         DBUS_TYPE_STRING, &property->name,
                                         DBUS_TYPE_INT32 , &match->method,
                                         DBUS_TYPE_STRING, &match->pattern,

--- a/src/dbus-proto.c
+++ b/src/dbus-proto.c
@@ -125,6 +125,7 @@ static resset_t *connect_to_manager(resconn_t *rcon, resmsg_t *resmsg)
     char          *name  =  RESPROTO_DBUS_MANAGER_NAME;
     uint32_t       id    =  resmsg->record.id;
     resmsg_rset_t *flags = &resmsg->record.rset;
+    const char    *app_id=  resmsg->record.app_id;
     const char    *klass =  resmsg->record.klass;
     uint32_t       mode  =  resmsg->record.mode;
     resset_t      *rset;
@@ -132,7 +133,7 @@ static resset_t *connect_to_manager(resconn_t *rcon, resmsg_t *resmsg)
     if ((rset = resset_find(rcon, name, id)) == NULL) {
         if (register_client_object(&rcon->dbus, id)) {
             rset = resset_create(rcon, name, id, RESPROTO_RSET_STATE_CREATED,
-                                 klass, mode, flags->all, flags->opt,
+                                 app_id, klass, mode, flags->all, flags->opt,
                                  flags->share, flags->mask);
         }
     }
@@ -679,6 +680,7 @@ static DBusHandlerResult manager_method(DBusConnection *dcon,
 
                 rset = resset_create(rcon, sender, resmsg.any.id,
                                      RESPROTO_RSET_STATE_CONNECTED,
+                                     resmsg.record.app_id,
                                      resmsg.record.klass,
                                      resmsg.record.mode,
                                      resmsg.record.rset.all,

--- a/src/internal-msg.c
+++ b/src/internal-msg.c
@@ -40,6 +40,7 @@ resmsg_t *resmsg_internal_copy_message(resmsg_t *src)
         case RESMSG_REGISTER:
         case RESMSG_UPDATE:
             dst->record = src->record;
+            dst->record.app_id = strdup(src->record.app_id);
             dst->record.klass = strdup(src->record.klass);
             break;
 
@@ -95,6 +96,7 @@ void resmsg_internal_destroy_message(resmsg_t *msg)
 
         case RESMSG_REGISTER:
         case RESMSG_UPDATE:
+            free(msg->record.app_id);
             free(msg->record.klass);
             break;
 

--- a/src/internal-proto.c
+++ b/src/internal-proto.c
@@ -134,6 +134,7 @@ static resset_t *connect_to_manager(resconn_t *rcon, resmsg_t *resmsg)
     char          *name  =  RESPROTO_INTERNAL_MANAGER;
     uint32_t       id    =  resmsg->any.id;
     resmsg_rset_t *flags = &resmsg->record.rset;
+    const char    *app_id=  resmsg->record.app_id;
     const char    *klass =  resmsg->record.klass;
     uint32_t       mode  =  resmsg->record.mode;
     resset_t      *rset;
@@ -143,7 +144,7 @@ static resset_t *connect_to_manager(resconn_t *rcon, resmsg_t *resmsg)
     else {
         if ((rset = resset_find(rcon, name, id)) == NULL) {
             rset = resset_create(rcon, name, id, RESPROTO_RSET_STATE_CREATED,
-                                 klass, mode, flags->all, flags->opt,
+                                 app_id, klass, mode, flags->all, flags->opt,
                                  flags->share, flags->mask);
         }
     }
@@ -335,6 +336,7 @@ static void receive_message_init(resconn_internal_t *rcon,
     resconn_qitem_t  buf;
     resconn_qitem_t *item;
     resmsg_rset_t   *flags;
+    const char      *app_id;
     const char      *klass;
     uint32_t         mode;
     
@@ -344,6 +346,7 @@ static void receive_message_init(resconn_internal_t *rcon,
     queue_was_empty = queue_is_empty(&rcon->queue.head);
 
     if (msg->type == RESMSG_REGISTER) {
+        app_id=  msg->record.app_id;
         klass =  msg->record.klass;
         mode  =  msg->record.mode;
         flags = &msg->record.rset;
@@ -351,7 +354,7 @@ static void receive_message_init(resconn_internal_t *rcon,
         if ((resset_find((resconn_t *)rcon, peer, msg->any.id)) == NULL) {
             resset_create((resconn_t *)rcon, peer, msg->any.id,
                           RESPROTO_RSET_STATE_CONNECTED,
-                          klass, mode, flags->all, flags->opt,
+                          app_id, klass, mode, flags->all, flags->opt,
                           flags->share, flags->mask);
         }
     }

--- a/src/res-msg.h
+++ b/src/res-msg.h
@@ -106,6 +106,7 @@ typedef struct {
 typedef struct {
     RESMSG_COMMON;               /* RESMSG_[REGISTER|UPDATE] */
     resmsg_rset_t     rset;      /* resource set */
+    char             *app_id;    /* mandatory application id */
     char             *klass;     /* optional application class */
     uint32_t          mode;      /* or'ed RESMSG_MODE_xxxx values */
 } resmsg_record_t;
@@ -122,7 +123,7 @@ typedef struct {
 typedef struct {
     RESMSG_COMMON;               /* RESMSG_AUDIO */
     char             *group;     /* group, if any ('' => registered class) */
-    uint32_t          pid;       /* PID of the streaming app, if any */
+    char             *app_id;    /* Application id of the streaming app, if any */
     resmsg_property_t property;  /* audio stream property */
 } resmsg_audio_t;
 
@@ -156,6 +157,7 @@ char *resmsg_res_str(uint32_t, char *, int);
 char *resmsg_mod_str(uint32_t, char *, int);
 char *resmsg_match_method_str(resmsg_match_method_t);
 
+char *resmsg_generate_app_id(pid_t pid);
 
 #ifdef	__cplusplus
 };

--- a/src/res-set-private.h
+++ b/src/res-set-private.h
@@ -26,7 +26,7 @@ USA.
 #include <res-set.h>
 
 resset_t *resset_create(union resconn_u*, const char*, uint32_t,
-                        resset_state_t, const char *, uint32_t,
+                        resset_state_t, const char *, const char *, uint32_t,
                         uint32_t, uint32_t, uint32_t, uint32_t);
 void      resset_destroy(resset_t *);
 void      resset_ref(resset_t *);

--- a/src/res-set.c
+++ b/src/res-set.c
@@ -32,6 +32,7 @@ resset_t *resset_create(resconn_t     *rcon,
                         const char    *peer,
                         uint32_t       id,
                         resset_state_t state,
+                        const char    *app_id,
                         const char    *klass,
                         uint32_t       mode,
                         uint32_t       all,
@@ -50,6 +51,7 @@ resset_t *resset_create(resconn_t     *rcon,
         rset->peer        = strdup(peer);
         rset->id          = id;
         rset->state       = state;
+        rset->app_id      = strdup(app_id);
         rset->klass       = strdup(klass);
         rset->mode        = mode,
         rset->flags.all   = all;
@@ -90,6 +92,7 @@ void resset_unref(resset_t *rset)
                 prev->next = rset->next;
                 
                 free(rset->peer);
+                free(rset->app_id);
                 free(rset->klass);
                 free(rset);
                 

--- a/src/res-set.h
+++ b/src/res-set.h
@@ -46,6 +46,7 @@ typedef struct resset_s {
     char             *peer;
     uint32_t          id;
     resset_state_t    state;
+    char             *app_id;
     char             *klass;
     uint32_t          mode;
     struct {

--- a/src/resource.h
+++ b/src/resource.h
@@ -82,6 +82,7 @@ int  resource_set_release(resource_set_t *resource_set);
 
 int  resource_set_is_acquiring(resource_set_t *resource_set);
 
+char *resource_generate_app_id(pid_t pid);
 
 #ifdef	__cplusplus
 };

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -8,6 +8,7 @@ TESTS = resource-test
 resource_test_SOURCES = resource-test.c ../src/resource.c
 
 resource_test_LDADD   = -lcheck                                 \
+                        $(top_builddir)/src/libresource.la      \
                         $(DBUS_LIBS)
 
 memory_leak_test_SOURCES = memory-leak-test.c

--- a/tests/resource-test.c
+++ b/tests/resource-test.c
@@ -274,6 +274,7 @@ typedef struct {
 struct resource_set_s {
     struct resource_set_s   *next;
     DBusConnection          *dbus;       /* D-Bus connection */
+    char                    *app_id;     /* application id */
     char                    *klass;      /* resource class */
     uint32_t                 id;         /* resource id */
     uint32_t                 mode;


### PR DESCRIPTION
Instead of using process id as means of identifier use the process
startup time formatted as hex.

This bit of information is identical from both outside of sandbox
and inside, which is needed when identifying a resource client from
either side.