### PR TITLE
Add missing include for sys/types.h

### DIFF
--- a/src/res-msg.h
+++ b/src/res-msg.h
@@ -24,6 +24,7 @@ USA.
 #define __RES_MESSAGE_H__
 
 #include <stdint.h>
+#include <sys/types.h>
 
 #include <res-types.h>
 


### PR DESCRIPTION
Without it, `pid_t` is undefined, at least on Musl libc.